### PR TITLE
Updates Confirmation Page to mirror Receipt Page (WIP)

### DIFF
--- a/burner-ui/src/Pages/ConfirmPage/ConfirmPage.tsx
+++ b/burner-ui/src/Pages/ConfirmPage/ConfirmPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router-dom';
 import { BurnerContext, withBurner } from '../../BurnerProvider';
 import Button from '../../components/Button';
@@ -6,6 +7,32 @@ import Page from '../../components/Page';
 import LineItem from '../../components/LineItem';
 import { Flex, Box, Card} from 'rimble-ui';
 import Text from '../../components/Text';
+import QRCode from 'qrcode.react';
+import TransactionDetails from '../../data-providers/TransactionDetails';
+import BalanceItem from '../../components/BalanceItem';
+import { Link } from '../../components/Button';
+
+const MetaKey = styled(Text)`
+  opacity: 0.6;
+  width: 5.5ch;
+  margin: 6px 0;
+`;
+
+const MetaValue = styled(Text)`
+  flex: 1 0 calc(100% - 5.5ch);
+  opacity: 0.6;
+  margin: 6px 0;
+`;
+
+const BottomButtonContainer = styled(Flex)`
+  position: fixed;
+  bottom: 24px;
+  color: #000;
+  font-weight: 600;
+  left: var(--page-margin);
+  right: var(--page-margin);
+`;
+
 
 const ConfirmPage: React.FC<BurnerContext & RouteComponentProps> = ({
   history,
@@ -62,24 +89,60 @@ const ConfirmPage: React.FC<BurnerContext & RouteComponentProps> = ({
 
   return (
     <Page title='Confirm' back>
-    <Box p={3}>
-    <Card p={2} borderRadius={2}>
-      <Flex flexDirection="column">
-      <Text level={2} as={'h2'}>From</Text>
-      <LineItem  value={from} />
-      <Text level={2} as={'h2'}>To</Text>
-      <LineItem  value={to} />
-      <Text level={2} as={'h2'}>Amount</Text>
-      <LineItem value={`${amount} ${asset.name}`} />
-      {message && <LineItem name='Message' value={message} />}
-      </Flex>
-    </Card>
-      <Flex mt={2}>
-        <Button disabled={sending} onClick={send}>
-          Send
-        </Button>
-      </Flex>
-      </Box>
+
+      <Box mt={24} padding='0 var(--page-margin)' as='section'>
+        <Flex flexWrap={'wrap'} flexDirection="column">
+          <Text level={4} margin={'0'}>From:</Text>
+          <LineItem value={from}>
+            { /*
+            {tx.from.substring(0, 8)} ...{' '}
+            {tx.from.substring(tx.from.length - 8, tx.from.length)}
+            */ }
+          </LineItem>
+          <Text level={3} margin={'0'}>To:</Text>
+          <LineItem value={to}>
+            { /*
+            {tx.to.substring(0, 8)} ...{' '}
+            {tx.to.substring(tx.to.length - 8, tx.to.length)}
+            */ }
+          </LineItem>
+          <Text level={3} margin={'0'}>Date:</Text>
+          <LineItem>#######</LineItem>
+        </Flex>
+        <Box mt={24}>
+          <Text level={2} as={'h2'}>
+            Sending
+          </Text>
+          <Card borderRadius={2} width={'240px'}>
+           <LineItem value={`${amount}`} />
+            <LineItem value={`${asset.name}`} />
+
+          </Card>
+          { /* Copied over from Receipt Page.
+            <BalanceItem
+              asset={{ name: tx.assetName }}
+              balance={tx.displayValue}
+            />{' '}
+             */}
+        </Box>
+        <Box mt={24}>
+            <Text level={2} as={'h2'}>
+              Message
+            </Text>
+            <Text level={3} as='div'>
+              {message && <LineItem name='Message' value={message} />}
+            </Text>
+          </Box>
+        </Box>
+
+        <Flex mt={2}>
+          <BottomButtonContainer>
+            <Button disabled={sending} onClick={send} width={'100%'}>
+              Send
+            </Button>
+          </BottomButtonContainer>
+        </Flex>
+
     </Page>
   );
 };

--- a/burner-ui/src/Pages/ConfirmPage/ConfirmPage.tsx
+++ b/burner-ui/src/Pages/ConfirmPage/ConfirmPage.tsx
@@ -95,15 +95,23 @@ const ConfirmPage: React.FC<BurnerContext & RouteComponentProps> = ({
           <Text level={4} margin={'0'}>From:</Text>
           <LineItem value={from}>
             { /*
-            {tx.from.substring(0, 8)} ...{' '}
-            {tx.from.substring(tx.from.length - 8, tx.from.length)}
+              Copied over from ReceiptPage
+              <MetaKey level={4}>From:</MetaKey>
+              <MetaValue level={4}>
+                {tx.from.substring(0, 8)} ...{' '}
+                {tx.from.substring(tx.from.length - 8, tx.from.length)}
+              </MetaValue>
             */ }
           </LineItem>
           <Text level={3} margin={'0'}>To:</Text>
           <LineItem value={to}>
             { /*
-            {tx.to.substring(0, 8)} ...{' '}
-            {tx.to.substring(tx.to.length - 8, tx.to.length)}
+              Copied over from Receipt Page
+              <MetaKey level={4}>To:</MetaKey>
+              <MetaValue level={4}>
+                {tx.to.substring(0, 8)} ...{' '}
+                {tx.to.substring(tx.to.length - 8, tx.to.length)}
+              </MetaValue>
             */ }
           </LineItem>
           <Text level={3} margin={'0'}>Date:</Text>
@@ -115,8 +123,7 @@ const ConfirmPage: React.FC<BurnerContext & RouteComponentProps> = ({
           </Text>
           <Card borderRadius={2} width={'240px'}>
            <LineItem value={`${amount}`} />
-            <LineItem value={`${asset.name}`} />
-
+           <LineItem value={`${asset.name}`} />
           </Card>
           { /* Copied over from Receipt Page.
             <BalanceItem
@@ -135,13 +142,11 @@ const ConfirmPage: React.FC<BurnerContext & RouteComponentProps> = ({
           </Box>
         </Box>
 
-        <Flex mt={2}>
           <BottomButtonContainer>
             <Button disabled={sending} onClick={send} width={'100%'}>
               Send
             </Button>
           </BottomButtonContainer>
-        </Flex>
 
     </Page>
   );

--- a/burner-ui/src/components/LineItem/index.tsx
+++ b/burner-ui/src/components/LineItem/index.tsx
@@ -7,7 +7,7 @@ const Line = styled.div`
 `;
 
 const TextLineName = styled.div`
-  font-size: 18;
+  font-size: 18px;
   font-weight: bold;
 `;
 
@@ -16,6 +16,7 @@ const TextLineValue = styled.div`
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 20px;
+  max-width: 240px;
 `;
 
 interface LineItemProps {


### PR DESCRIPTION
This is a work-in-progress that @carlfairclough will need to look at. There are several aspects I couldn't reproduce / port over from the `Receipt` page.

**Pre-Merge To Do List**

1. - [ ] Bring in the `MetaKey` and `MetaValue` components and pass values through them OR just accept the current implementation - you decide.

2. - [ ] Replace the `Card` component displaying the Transaction `amount` and `asset.name` with the `BalanceItem` used in the `Receipt` page.

3. - [ ] Expand the Send `Button` to have `width: 100%`. 
**NB** I tried to do this, but for some reason the class was being appended to the element's `:before` pseudoselector.