### PR TITLE
Updates the HomePage with new wrapper & design

### DIFF
--- a/burner-ui/src/Pages/HomePage/HomePage.tsx
+++ b/burner-ui/src/Pages/HomePage/HomePage.tsx
@@ -60,14 +60,14 @@ interface HomePageProps {
 }
 
 const TabButton = styled.button`
-  background: ${(props) => (props.selected ? 'var(--color-primary)' : 'var(--color-tertiary)')};
+  background: ${(props) => (props.selected ? 'var(--color-primary)' : 'transparent')};
   border-radius: 30px;
   display: flex;
   font-size: 16px;
   align-items: center;
   color: ${(props) => (props.selected ? 'var(--color-tertiary)' : 'var(--color-primary)')};
   padding: 8px 12px;
-  border: none;
+  border: 1px solid var(--color-primary);
   outline: none;
   margin: 0 4px;
   transition: 0.15s ease-in-out;

--- a/burner-ui/src/Pages/HomePage/HomePage.tsx
+++ b/burner-ui/src/Pages/HomePage/HomePage.tsx
@@ -78,7 +78,8 @@ const TabButton = styled.button`
 `;
 
 const HomeTopWrapper = styled(Box)`
-background: var(--color-makergradient);
+background: transparent;
+border-bottom: 1px solid #f2f2f2;
   padding: var(--page-margin);
 
 

--- a/burner-ui/src/Pages/HomePage/HomePage.tsx
+++ b/burner-ui/src/Pages/HomePage/HomePage.tsx
@@ -77,6 +77,16 @@ const TabButton = styled.button`
   }
 `;
 
+const HomeTopWrapper = styled(Box)`
+background: var(--color-makergradient);
+  padding: var(--page-margin);
+
+
+@media (max-width: 320px) {
+    padding: 4px;
+  }
+`
+
 const HomePage: React.FC<BurnerContext> = ({ defaultAccount, actions, pluginData }) => {
   const [tab, setTab] = useState(0);
 
@@ -87,10 +97,13 @@ const HomePage: React.FC<BurnerContext> = ({ defaultAccount, actions, pluginData
   const { Component: TabComponent, plugin: tabPlugin } = homeTabs[tab];
 
   return (
-    <StyledPage title="My Wallet">
+    <StyledPage>
       <PluginElements position="home-top" />
 
-      <Box margin="0 var(--page-margin)">
+      <HomeTopWrapper>
+      <Flex flexDirection={'column'}>
+      <Flex flexDirection={'row'} justifyContent={'space-between'}>
+      <Text level={1} as={'h1'} px={3} my={0}>My Wallet</Text>
         <Flex justifyContent="space-between" alignItems="center" my={2}>
           <Flex>
             {homeTabs.map(({ options }: PluginElementData, i: number) => (
@@ -100,9 +113,11 @@ const HomePage: React.FC<BurnerContext> = ({ defaultAccount, actions, pluginData
             ))}
           </Flex>
         </Flex>
-      </Box>
+      </Flex>
 
       <TabComponent plugin={tabPlugin} />
+      </Flex>
+      </HomeTopWrapper>
 
       <PluginElements position="home-middle" />
       <Box margin="0 var(--page-margin)">

--- a/burner-ui/src/components/BalanceItem/BalanceItem.tsx
+++ b/burner-ui/src/components/BalanceItem/BalanceItem.tsx
@@ -52,7 +52,9 @@ const BalanceCard = styled(Card)`
   max-width: calc(6ch + 24px);
   text-align: right;
   padding: 8px 16px 8px 8px;
+  border: 1px solid #ccc;
   border-radius: 8px;
+  box-shadow: none;
   &:not(:first-of-type) {
     margin-left: 12px;
   }

--- a/burner-ui/src/components/BalanceRow/BalanceRow.tsx
+++ b/burner-ui/src/components/BalanceRow/BalanceRow.tsx
@@ -6,7 +6,7 @@ import { withBurner, BurnerContext } from "../../BurnerProvider";
 import BalanceItem from '../BalanceItem';
 
 const Row = styled.section`
-  padding: 32px var(--page-margin);
+  padding: 32px 0;
   width: 100%;
   overflow-x: scroll;
   white-space: nowrap;


### PR DESCRIPTION
<img width="382" alt="Screen Shot 2019-10-07 at 4 17 59 PM" src="https://user-images.githubusercontent.com/6787950/66291971-114c1400-e91e-11e9-9b1b-5f35f087f489.png">

Wraps the top half of the HomePage and adds the maker gradient var as a background.
Updates the tab button styling slightly to improve legibility w/ the new background.