### PR TITLE
Updates to send modal

### DIFF
--- a/burner-ui/src/GlobalStyle.tsx
+++ b/burner-ui/src/GlobalStyle.tsx
@@ -31,8 +31,11 @@ const GlobalStyle = createGlobalStyle`
     --color-tertiary: #D2F9F5;
     --color-makergradient: linear-gradient(180deg, rgba(182, 237, 231, 0.38) 0%, rgba(253, 193, 52, 0.15) 100%);
     --color-makergradientdarker: linear-gradient(180deg, rgba(16, 230, 206, 0.38) 15.63%, rgba(255, 187, 28, 0.25) 100%);
+    --color-makerheadline: #291a42;
 
     --color-nearblack: #291a42;
+
+    --color-disabled: #bbddd9;
 
     --modal-background: #E1DEFF;
     --modal-header-background: #CAC4FF;

--- a/burner-ui/src/Modals/Send/Send.tsx
+++ b/burner-ui/src/Modals/Send/Send.tsx
@@ -81,10 +81,10 @@ const TitleBar = styled(Box)`
 `;
 
 const AmountWrapper = styled(Flex)`
-  padding: 0 var(--page-margin);
   align-items: center;
   flex-direction: column;
   flex: 1;
+  text-align: center;
 `;
 
 
@@ -336,9 +336,11 @@ class SendModal extends Component<SendPageProps, SendPageState> {
                     flexDirection={'column'}
                     justifyContent={'center'}
                   >
-                    <TransactionCardHeader>
+                    <TransactionCardHeader
+                    backgroundColor={'var(--color-makergradient)'}
+                    >
                     <TitleBar>
-                      <Text level={1} as={'h1'} m={0} color={'var(--color-primary)'}>
+                      <Text level={1} as={'h1'} color={'var(--color-makerheadline)'}>
                         Send To
                       </Text>
 
@@ -373,7 +375,7 @@ class SendModal extends Component<SendPageProps, SendPageState> {
                     </TransactionCardHeader>
                     <TransactionCardBody>
                     <AmountWrapper>
-                      <Text level={2} as={'h2'} color={'var(--color-nearblack)'}>
+                      <Text level={2} as={'h2'} color={'var(--color-nearblack)'} textAlign={'center'}>
                         How much do you want to send?
                       </Text>
                       <RimbleAmountInput

--- a/burner-ui/src/Modals/Send/Send.tsx
+++ b/burner-ui/src/Modals/Send/Send.tsx
@@ -340,7 +340,7 @@ class SendModal extends Component<SendPageProps, SendPageState> {
                     backgroundColor={'var(--color-makergradient)'}
                     >
                     <TitleBar>
-                      <Text level={1} as={'h1'} color={'var(--color-makerheadline)'}>
+                      <Text level={1} as={'h1'} margin='8px 0px 16px 0px' color={'var(--color-primary)'}>
                         Send To
                       </Text>
 
@@ -417,7 +417,7 @@ class SendModal extends Component<SendPageProps, SendPageState> {
                   </TransactionCard>
                   <SendButton
                     width={'100%'}
-                    my={2}
+                    mt={2}
                     onClick={() => this.send()}
                     disabled={!canSend || exceedsBalance}
                   >

--- a/burner-ui/src/components/AmountInput.tsx
+++ b/burner-ui/src/components/AmountInput.tsx
@@ -34,6 +34,7 @@ const Input = styled.input`
   font-size: 16px;
   padding: 4px;
   background: transparent;
+  align-content: center;
 `;
 
 const MaxBtn = styled.div`

--- a/burner-ui/src/components/AssetSelector.tsx
+++ b/burner-ui/src/components/AssetSelector.tsx
@@ -15,9 +15,8 @@ const Wrapper = styled.div`
   flex: 1 0;
   cursor: default;
   padding: 8px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-  box-shadow: 0px 2px 4px rgba(0,0,0,0.2);
+  margin: 8px
+  border: 1px solid hsla(0, 0%, 90%, 1);
 `;
 
 const TextAssetName = styled(Text)`
@@ -89,15 +88,10 @@ const ItemWrapper = styled.div`
   left: 0;
   right: 0;
   padding: 6px;
-  box-shadow: 0px 3px 5px 0px #999;
   border-radius: 4px;
   z-index: 10;
   &:hover {
     background: #efefef;
-  }
-
-  &:Wrapper {
-    box-shadow: none;
   }
 `;
 

--- a/burner-ui/src/components/RimbleAmountInput/index.tsx
+++ b/burner-ui/src/components/RimbleAmountInput/index.tsx
@@ -26,6 +26,8 @@ const Unit = styled.div`
 `;
 
 const StyledInput = styled(Input)`
+  display: flex;
+  align-content: center;
   width: 100%;
   height: 100%;
   border: 0;

--- a/burner-ui/src/components/RimbleInput.jsx
+++ b/burner-ui/src/components/RimbleInput.jsx
@@ -18,7 +18,7 @@ export const TransferMessageInput = styled(Input)`
   transition: 0.15s ease-in-out;
 
   &:focus {
-    background: #E1DEFF;
+    background: hsla(0, 0%, 90%, 1);
     box-shadow: none;
     text-align: center;
   }

--- a/burner-ui/src/components/TransactionCard/index.jsx
+++ b/burner-ui/src/components/TransactionCard/index.jsx
@@ -8,6 +8,7 @@ export const TransactionCard = styled(Card)`
   display: flex;
   flex: 1;
   flex-direction: column;
+  justify-content: space-between;
   border-radius: 8px;
   padding: 0px;
   color: #4E3FCE;
@@ -18,11 +19,12 @@ export const TransactionCardHeader = styled(Flex)`
   padding: 16px;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
+  background: var(--color-makergradient);
 `
 
 export const TransactionCardBody = styled(Flex)`
   display: flex;
-  flex: 1;
+  overflow: scroll;
   flex-direction: column;
   align-items: center;
   justify-items: center;
@@ -34,6 +36,7 @@ export const TransactionCardFooter = styled(Flex)`
   align-items: center;
   width: 100%;
   padding: 8px 16px;
+  border-top: 1px solid hsla(0, 0%, 90%, 1);
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
   box-sizing: border-box;


### PR DESCRIPTION
Updated TransactionCard with `flex: 1` to make it wrap to the whole screen & set the `TransactionCardBody` to `overflow: scroll` to accommodate the iPhone XS screensize.

Also updated styling on the `AssetSelector` so it fits "in" a little better with the rest of the modal.