### PR TITLE
Alpha request screen

### DIFF
--- a/burner-ui/src/Modals/Receive/index.tsx
+++ b/burner-ui/src/Modals/Receive/index.tsx
@@ -41,6 +41,10 @@ const StyledInput = styled(Input)`
   white-space: nowrap;
 `;
 
+const Header = styled(Box)`
+background: var(--color-makergradient);
+`
+
 interface AddressQrModalProps {
   isOpen: boolean;
   hide: Function;
@@ -97,18 +101,19 @@ class ReceiveModal extends Component<AddressQrModalProps> {
               />
 
 
-              <Box p={[3, 4]} pt={0} overflow={'scroll'}>
+              <Header p={[3, 4]} pt={0} overflow={'scroll'}>
               <Text
                 level={1}
                 as={'h1'}
-                center
+                color={'var(--color-primary)'}
+                left
               >
                 {text.title}
               </Text>
-                <Text level={3} as={'p'} margin={0} center>
+                <Text level={3} as={'p'} margin={0} left>
                   {text.description}
                 </Text>
-              </Box>
+              </Header>
                 <Box
                   // size={['100%', '200px']}
                   width={1}
@@ -155,6 +160,7 @@ class ReceiveModal extends Component<AddressQrModalProps> {
                   </Clipboard>
                 </Box>
             </Card>
+            {/*
             <Card borderRadius={2} border={0} padding={2} marginTop='var(--page-margin)' backgroundColor={'var(--color-tertiary)'}>
               <Flex flexDirection={'row'} alignItems={'center'}>
               <Box borderRadius={'100px'} backgroundColor={'var(--color-primary)'}>
@@ -167,6 +173,7 @@ class ReceiveModal extends Component<AddressQrModalProps> {
               </Box>
               </Flex>
             </Card>
+            */}
           </ModalBackdrop>
         </Portal>
       )

--- a/burner-ui/src/Pages/CreateRequestPage/CreateRequestPage.tsx
+++ b/burner-ui/src/Pages/CreateRequestPage/CreateRequestPage.tsx
@@ -52,6 +52,7 @@ const ReceivePage: React.FC<BurnerContext> = ({ actions, history, assets }) => {
             onChange={newAsset => setAsset(newAsset)}
           />
           <TransactionCardFooter>
+          {/*
           {asset.supportsMessages() && (
             <Fragment>
               <Text level={3} as="h3" margin={0} color={'var(--color-nearblack)'}>
@@ -63,7 +64,9 @@ const ReceivePage: React.FC<BurnerContext> = ({ actions, history, assets }) => {
                 onChange={(e) => this.setState({ message: e.target.value })}
               />
             </Fragment>
+
           )}
+          */}
           </TransactionCardFooter>
         </TransactionCard>
       </Flex>

--- a/burner-ui/src/Pages/CreateRequestPage/CreateRequestPage.tsx
+++ b/burner-ui/src/Pages/CreateRequestPage/CreateRequestPage.tsx
@@ -11,16 +11,14 @@ import {
 } from '../../components/TransactionCard';
 import AssetSelector from '../../components/AssetSelector';
 import Button from '../../components/Button';
-import RimbleInput from '../../components/RimbleInput';
+import {
+  RimbleInput,
+  TransferMessageInput
+} from '../../components/RimbleInput';
+import RimbleAmountInput from '../../components/RimbleAmountInput';
+import Text from '../../components/Text';
 import { Flex } from 'rimble-ui';
 
-// To Do: This is also used by SendPage.tsx & should be migrated to an independent component to avoid consistency errors.
-const TransferMessageInput = styled(RimbleInput)`
-  background: transparent;
-  box-shadow: none;
-  border: 0px;
-  outline: 0px;
-`;
 
 const ReceivePage: React.FC<BurnerContext> = ({ actions, history, assets }) => {
   const [amount, setAmount] = useState(
@@ -29,18 +27,20 @@ const ReceivePage: React.FC<BurnerContext> = ({ actions, history, assets }) => {
   const [message, setMessage] = useState('');
   const [asset, setAsset] = useState(assets[0]);
   return (
-    <Page title='Request' close>
+    <Page>
       <Flex flexDirection='column' p={3}>
         <TransactionCard>
           <TransactionCardHeader>
-            <h3>Scan Request</h3>
-            <p>
+            <Text level={1} as={'h1'} margin='8px 0px 16px 0px' color={'var(--color-primary)'}>
+              Request
+            </Text>
+            <Text level={2} as='p' color={'var(--color-nearblack)'}>
               Creates a QR code with your transaction request for someone to
               scan
-            </p>
+            </Text>
           </TransactionCardHeader>
           <TransactionCardBody>
-            <h3>How much do you want to request?</h3>
+            <Text level={3} as="p" color={'var(--color-nearblack)'}>How much do you want to request?</Text>
             <RimbleAmountInput
               value={amount}
               placeholder='0'
@@ -52,24 +52,33 @@ const ReceivePage: React.FC<BurnerContext> = ({ actions, history, assets }) => {
             onChange={newAsset => setAsset(newAsset)}
           />
           <TransactionCardFooter>
-            {asset.supportsMessages() && (
-              <Fragment>
-                <div>For:</div>
-                <TransferMessageInput
-                  value={message}
-                  onChange={e => this.setState({ message: e.target.value })}
-                />
-              </Fragment>
-            )}
+          {asset.supportsMessages() && (
+            <Fragment>
+              <Text level={3} as="h3" margin={0} color={'var(--color-nearblack)'}>
+                For:
+              </Text>
+              <TransferMessageInput
+                placeholder="Optional"
+                value={message}
+                onChange={(e) => this.setState({ message: e.target.value })}
+              />
+            </Fragment>
+          )}
           </TransactionCardFooter>
         </TransactionCard>
       </Flex>
-      <Button onClick={() => actions.navigateTo('/receive')}>Cancel</Button>
+      <Flex justifyContent={'space-between'} margin={'0 var(--page-margin)'}>
       <Button
+       background='var(--color-tertiary)'
+       onClick={() => actions.navigateTo('/')}>Back</Button>
+      <Button
+        width={'100%'}
+        background='var(--color-primary)'
         onClick={() => actions.navigateTo('/request/display', { amount })}
       >
         Next
       </Button>
+      </Flex>
     </Page>
   );
 };

--- a/burner-ui/src/Pages/DisplayRequestPage/DisplayRequestPage.tsx
+++ b/burner-ui/src/Pages/DisplayRequestPage/DisplayRequestPage.tsx
@@ -17,7 +17,7 @@ const QRWrapper = styled.div`
   justify-content: center;
   padding: 16px;
   margin: 16px;
-  border: 1px solid #999;
+  border: 1px solid #444;
   border-radius: 8px;
 `
 
@@ -29,11 +29,11 @@ const DisplayRequestPage = ({ history, actions }) => {
   const { amount } = history.location.state;
 
   return (
-    <Page title="Requesting" back>
+    <Page>
       <Flex flexDirection="column" p={3}>
       <TransactionCard>
         <TransactionCardHeader>
-        <Text level={3} as="h1" center>Please scan this QR code to complete the transaction.</Text>
+        <Text level={2} as="h1" center color={'var(--color-nearblack)'}>Please scan this QR code to complete the transaction.</Text>
         </TransactionCardHeader>
         <TransactionCardBody>
           <QRWrapper>

--- a/burner-ui/src/Pages/Pages.tsx
+++ b/burner-ui/src/Pages/Pages.tsx
@@ -4,8 +4,8 @@ import { BurnerPluginData } from '../Plugins';
 import ActivityPage from './ActivityPage';
 import AdvancedPage from './AdvancedPage';
 import ConfirmPage from './ConfirmPage';
-// import CreateRequestPage from './CreateRequestPage';
-// import DisplayRequestPage from './DisplayRequestPage';
+import CreateRequestPage from './CreateRequestPage';
+import DisplayRequestPage from './DisplayRequestPage';
 import HomePage from './HomePage';
 import ReceiptPage from './ReceiptPage';
 import ReceivePage from './ReceivePage';
@@ -22,8 +22,8 @@ const Pages: React.FC<PageProps> = ({ pluginData }) => (
     <Route path='/activity' exact component={ActivityPage} />
     <Route path='/welcome' exact component={Onboarding} />
     <Route path='/receive' component={ReceivePage} />
-    {/* <Route path='/request/display' component={DisplayRequestPage} />
-    <Route path='/request' component={CreateRequestPage} /> */}
+    <Route path='/request/display' component={DisplayRequestPage} />
+    <Route path='/request' component={CreateRequestPage} />
     <Route path='/confirm' component={ConfirmPage} />
     <Route path='/receipt/:asset/:txHash' component={ReceiptPage} />
     <Route path='/advanced' component={AdvancedPage} />

--- a/burner-ui/src/Pages/ReceivePage/ReceivePage.tsx
+++ b/burner-ui/src/Pages/ReceivePage/ReceivePage.tsx
@@ -93,12 +93,12 @@ const ReceivePage: React.FC<BurnerContext> = ({ defaultAccount, actions }) => {
 
         <ScanRequestCard onClick={() => actions.navigateTo('/request')}>
           <ScanRequestHeader>
-            <IcoScanRequest></IcoScanRequest>
             <Text level={3} as={'h1'}>
               Create Request
             </Text>
           </ScanRequestHeader>
           <Text level={3} as={'p'}>
+            {'u/2197'}
             Creates a QR code that someone can scan to pay you.
           </Text>
         </ScanRequestCard>


### PR DESCRIPTION
Brings in a request screen we can get from the hardcoded `/request` url.

Removes a link to that screen from the Receive modal. We'll only use it as a backup. 

Small styling fixes to get it consistent.
