### PR TITLE
Fix send modal bug

### DIFF
--- a/burner-ui/src/Modals/Send/Send.tsx
+++ b/burner-ui/src/Modals/Send/Send.tsx
@@ -105,6 +105,7 @@ const MaxButton = styled(Button)`
   margin: 8px 0px;
   border: 0px;
   text-transform: uppercase;
+  height: 32px;
 
   &:focus {
     outline: none;

--- a/burner-ui/src/Modals/Send/Send.tsx
+++ b/burner-ui/src/Modals/Send/Send.tsx
@@ -354,7 +354,7 @@ class SendModal extends Component<SendPageProps, SendPageState> {
 
                       <Button.Text
                         icon={'Close'}
-                        mainColor={'inherit'}
+                        mainColor={'var(--color-primary)'}
                         p={0}
                         borderRadius={'100%'}
                         position={'absolute'}

--- a/burner-ui/src/Modals/Send/Send.tsx
+++ b/burner-ui/src/Modals/Send/Send.tsx
@@ -58,6 +58,13 @@ const ModalBackdrop = styled(Box)`
   }
 `;
 
+const ModalWrapper = styled(Flex)`
+  flex-direction: column;
+  flex: 1;
+  justify-content: space-between;
+  height: ${window.innerHeight}px;
+`
+
 const PurpleCard = styled(Card)`
   background-color: var(--modal-header-background);
   height: 100%;
@@ -325,6 +332,7 @@ class SendModal extends Component<SendPageProps, SendPageState> {
             return (
               <Portal>
                 <ModalBackdrop>
+                <ModalWrapper>
                   <TransactionCard
                     width={1}
                     maxWidth={6}
@@ -423,6 +431,7 @@ class SendModal extends Component<SendPageProps, SendPageState> {
                   >
                     Send
                   </SendButton>
+                  </ModalWrapper>
                 </ModalBackdrop>
               </Portal>
             );

--- a/burner-ui/src/Template.tsx
+++ b/burner-ui/src/Template.tsx
@@ -40,11 +40,6 @@ const styles = (theme: any) => ({
       width: '100%'
     },
     '#root': {
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      height: '100%'
     }
   }
 });

--- a/burner-ui/src/components/AddressInputField/index.tsx
+++ b/burner-ui/src/components/AddressInputField/index.tsx
@@ -37,19 +37,24 @@ const ButtonScan = styled.button`
 const ButtonClear = styled.button`
   font-size: 32px;
   color: #4e3fce;
+  background: transparent;
+  border: 0px;
+  outline: none;
 `;
 
 const StyledWrapper = styled(Box)`
   & {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: baseline;
     width: 100%;
+    max-width: 320px;
     position: relative;
   }
 `;
 
 const StyledInput = styled(Input)`
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
@@ -91,13 +96,13 @@ const AddressInputField: React.FC<AddressInputFieldProps> = ({
             fontWeight={3}
             onChange={e => onChange(e.target.value, null)}
           />
-          <Flex position={'absolute'} right={0} mr={2}>
+          <Flex position={'absolute'} right={0} mr={1} bottom='8px'>
             <Button size={'small'} mx={2} p={0} onClick={scan}>
               <Icon name='CenterFocusWeak' />
             </Button>
           </Flex>
           {scan && (
-            <Flex position={'absolute'} right={0} mr={2}>
+            <Flex position={'absolute'} right={0} mr={1} bottom='8px'>
               <Button size={'small'} mx={2} p={0} onClick={scan}>
                 <Icon name='CenterFocusWeak' />
               </Button>

--- a/burner-ui/src/components/AddressInputField/index.tsx
+++ b/burner-ui/src/components/AddressInputField/index.tsx
@@ -36,7 +36,7 @@ const ButtonScan = styled.button`
 
 const ButtonClear = styled.button`
   font-size: 32px;
-  color: #4e3fce;
+  color: var(--color-primary);
   background: transparent;
   border: 0px;
   outline: none;

--- a/burner-ui/src/components/AddressInputField/index.tsx
+++ b/burner-ui/src/components/AddressInputField/index.tsx
@@ -97,13 +97,13 @@ const AddressInputField: React.FC<AddressInputFieldProps> = ({
             onChange={e => onChange(e.target.value, null)}
           />
           <Flex position={'absolute'} right={0} mr={1} bottom='8px'>
-            <Button size={'small'} mx={2} p={0} onClick={scan}>
+            <Button size={'small'} mx={2} p={0} onClick={scan} mainColor="var(--color-primary)">
               <Icon name='CenterFocusWeak' />
             </Button>
           </Flex>
           {scan && (
             <Flex position={'absolute'} right={0} mr={1} bottom='8px'>
-              <Button size={'small'} mx={2} p={0} onClick={scan}>
+              <Button size={'small'} mx={2} p={0} onClick={scan} mainColor="var(--color-primary)">
                 <Icon name='CenterFocusWeak' />
               </Button>
             </Flex>

--- a/burner-ui/src/components/RimbleAmountInput/index.tsx
+++ b/burner-ui/src/components/RimbleAmountInput/index.tsx
@@ -36,7 +36,7 @@ const StyledInput = styled(Input)`
   background: none;
   box-shadow: none;
   text-align: center;
-  margin: 1rem 0rem;
+  padding: 0;
 
   :focus {
     box-shadow: none;

--- a/burner-ui/src/components/TransactionCard/index.jsx
+++ b/burner-ui/src/components/TransactionCard/index.jsx
@@ -11,7 +11,7 @@ export const TransactionCard = styled(Card)`
   justify-content: space-between;
   border-radius: 8px;
   padding: 0px;
-  color: #4E3FCE;
+  color: var(--color-primary);
 `
 
 export const TransactionCardHeader = styled(Flex)`


### PR DESCRIPTION
Attempts to fix a bunch of functional & aesthetic consistency issues with the Send modal.

Biggest thing is setting a new `ModalWrapper` that wraps both the `TransactionCard` and the `SendButton` and is set to `height: window.innerHeight` to try and resolve the browser chrome overlap issue.